### PR TITLE
feat(dream): 관리자용 꿈일기 삭제 기능 추가, 리팩토링

### DIFF
--- a/src/main/java/dev/wgrgwg/somniverse/comment/controller/CommentController.java
+++ b/src/main/java/dev/wgrgwg/somniverse/comment/controller/CommentController.java
@@ -90,8 +90,7 @@ public class CommentController {
 
     @PreAuthorize("hasAnyAuthority('ADMIN', 'MANAGER')")
     @DeleteMapping("/comments/admin/{commentId}")
-    public ResponseEntity<ApiResponseDto<Void>> deleteCommentByAdmin(@PathVariable Long commentId,
-        @AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<ApiResponseDto<Void>> deleteCommentByAdmin(@PathVariable Long commentId) {
         commentService.deleteCommentByAdmin(commentId);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();

--- a/src/main/java/dev/wgrgwg/somniverse/dream/controller/DreamController.java
+++ b/src/main/java/dev/wgrgwg/somniverse/dream/controller/DreamController.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -75,6 +76,14 @@ public class DreamController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'MANAGER')")
+    @DeleteMapping("/admin/{dreamId}")
+    public ResponseEntity<ApiResponseDto<Void>> deleteDreamByAdmin(@PathVariable Long dreamId) {
+        dreamService.deleteDreamByAdmin(dreamId);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
     @GetMapping("/my")
     public ResponseEntity<ApiResponseDto<Page<DreamSimpleResponse>>> getMyDreams(
         @AuthenticationPrincipal CustomUserDetails userDetails, Pageable pageable) {
@@ -111,6 +120,7 @@ public class DreamController {
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.success(response));
     }
 
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'MANAGER')")
     @GetMapping("/admin")
     public ResponseEntity<ApiResponseDto<Page<DreamSimpleResponse>>> getDreamsForAdmin(
         Pageable pageable, @RequestParam(defaultValue = "false") Boolean includeDeleted) {
@@ -121,6 +131,7 @@ public class DreamController {
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.success(response));
     }
 
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'MANAGER')")
     @GetMapping("/admin/{dreamId}")
     public ResponseEntity<ApiResponseDto<DreamResponse>> getDreamAsAdmin(@PathVariable Long dreamId,
         @RequestParam(defaultValue = "false") Boolean includeDeleted) {

--- a/src/main/java/dev/wgrgwg/somniverse/dream/domain/Dream.java
+++ b/src/main/java/dev/wgrgwg/somniverse/dream/domain/Dream.java
@@ -43,6 +43,7 @@ public class Dream {
     private LocalDate dreamDate;
 
     @OneToMany(mappedBy = "dream")
+    @Builder.Default
     private List<Comment> comments = new ArrayList<>();
 
     private boolean isPublic;

--- a/src/main/java/dev/wgrgwg/somniverse/dream/service/DreamService.java
+++ b/src/main/java/dev/wgrgwg/somniverse/dream/service/DreamService.java
@@ -118,6 +118,13 @@ public class DreamService {
         dream.softDelete();
     }
 
+    @Transactional
+    public void deleteDreamByAdmin(Long dreamId) {
+        Dream dream = getDreamOrThrow(dreamId);
+
+        dream.softDelete();
+    }
+
     public Dream getDreamOrThrow(Long dreamId) {
         return dreamRepository.findByIdAndIsDeletedFalse(dreamId)
             .orElseThrow(() -> new CustomException(DreamErrorCode.DREAM_NOT_FOUND));

--- a/src/test/java/dev/wgrgwg/somniverse/comment/service/CommentServiceTest.java
+++ b/src/test/java/dev/wgrgwg/somniverse/comment/service/CommentServiceTest.java
@@ -55,7 +55,6 @@ class CommentServiceTest {
 
     private Member testMember;
     private Member otherMember;
-    private Member adminMember;
     private Dream testDream;
     private Comment parentComment;
     private Comment childComment;
@@ -64,7 +63,6 @@ class CommentServiceTest {
     void setUp() {
         testMember = Member.builder().id(1L).username("testuser").role(Role.USER).build();
         otherMember = Member.builder().id(2L).username("otheruser").role(Role.USER).build();
-        adminMember = Member.builder().id(99L).username("admin").role(Role.ADMIN).build();
 
         testDream = Dream.builder().id(101L).member(otherMember).build();
 

--- a/src/test/java/dev/wgrgwg/somniverse/dream/controller/DreamControllerTest.java
+++ b/src/test/java/dev/wgrgwg/somniverse/dream/controller/DreamControllerTest.java
@@ -168,7 +168,7 @@ class DreamControllerTest {
     class DeleteDreamApiTests {
 
         @Test
-        @DisplayName("꿈일기 삭제 성공 시 204 NO CONTENT 반환")
+        @DisplayName("꿈일기 삭제 성공 시 204 NO CONTENT")
         void deleteDream_success_test() throws Exception {
             // given
             long dreamId = 101L;
@@ -179,6 +179,12 @@ class DreamControllerTest {
 
             // then
             resultActions.andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("")
+        void deleteDreamByAdmin_success_test() throws Exception {
+
         }
     }
 
@@ -315,7 +321,8 @@ class DreamControllerTest {
             MemberResponse author = new MemberResponse(1L, "test@email.com", "testuser", "USER",
                 LocalDateTime.now());
             DreamResponse dreamResponse = new DreamResponse(dreamId, "나의 비공개 꿈",
-                "내용", LocalDate.now(), false, LocalDateTime.now(), LocalDateTime.now(), author, false);
+                "내용", LocalDate.now(), false, LocalDateTime.now(), LocalDateTime.now(), author,
+                false);
             when(dreamService.getMyDream(anyLong(), anyLong())).thenReturn(dreamResponse);
 
             // when

--- a/src/test/java/dev/wgrgwg/somniverse/dream/service/DreamServiceTest.java
+++ b/src/test/java/dev/wgrgwg/somniverse/dream/service/DreamServiceTest.java
@@ -78,7 +78,7 @@ class DreamServiceTest {
 
     @Nested
     @DisplayName("꿈일기 생성 테스트")
-    class createDreamTests {
+    class CreateDreamTests {
 
         @Test
         @DisplayName("꿈일기 생성 성공하면 DreamResponse 반환")
@@ -106,7 +106,7 @@ class DreamServiceTest {
 
     @Nested
     @DisplayName("꿈일기 단건 조회 테스트")
-    class getDreamTests {
+    class GetDreamTests {
 
         @Test
         @DisplayName("꿈일기 조회 성공하면 DreamResponse 반환")
@@ -211,23 +211,27 @@ class DreamServiceTest {
                 .thenReturn(dreamPage);
 
             // when
-            Page<DreamSimpleResponse> resultPage = dreamService.getMyDreams(testMember.getId(), pageable);
+            Page<DreamSimpleResponse> resultPage = dreamService.getMyDreams(testMember.getId(),
+                pageable);
 
             // then
             assertThat(resultPage).isNotNull();
             assertThat(resultPage.getTotalElements()).isEqualTo(2);
             assertThat(resultPage.getContent()).hasSize(2);
             assertThat(resultPage.getContent().get(0).title()).isEqualTo("꿈1");
-            assertThat(resultPage.getContent().get(1).authorUsername()).isEqualTo(testMember.getUsername());
+            assertThat(resultPage.getContent().get(1).authorUsername()).isEqualTo(
+                testMember.getUsername());
 
-            verify(dreamRepository).findAllByMemberIdAndIsDeletedFalse(testMember.getId(), pageable);
+            verify(dreamRepository).findAllByMemberIdAndIsDeletedFalse(testMember.getId(),
+                pageable);
         }
 
         @Test
         @DisplayName("전체 공개 꿈일기 목록 조회 성공 시 Page 응답 반환")
         void getPublicDreams_whenCalled_shouldReturnPagedResponse() {
             // given
-            when(dreamRepository.findAllByIsPublicTrueAndIsDeletedFalse(pageable)).thenReturn(dreamPage);
+            when(dreamRepository.findAllByIsPublicTrueAndIsDeletedFalse(pageable)).thenReturn(
+                dreamPage);
 
             // when
             Page<DreamSimpleResponse> resultPage = dreamService.getPublicDreams(pageable);
@@ -248,7 +252,8 @@ class DreamServiceTest {
                 otherMember.getId(), pageable)).thenReturn(dreamPage);
 
             // when
-            Page<DreamSimpleResponse> resultPage = dreamService.getPublicDreamsByMember(otherMember.getId(), pageable);
+            Page<DreamSimpleResponse> resultPage = dreamService.getPublicDreamsByMember(
+                otherMember.getId(), pageable);
 
             // then
             assertThat(resultPage).isNotNull();
@@ -267,7 +272,8 @@ class DreamServiceTest {
                 .thenReturn(emptyPage);
 
             // when
-            Page<DreamSimpleResponse> resultPage = dreamService.getMyDreams(testMember.getId(), pageable);
+            Page<DreamSimpleResponse> resultPage = dreamService.getMyDreams(testMember.getId(),
+                pageable);
 
             // then
             assertThat(resultPage).isNotNull();
@@ -276,13 +282,14 @@ class DreamServiceTest {
             assertThat(resultPage.isFirst()).isTrue();
             assertThat(resultPage.isLast()).isTrue();
 
-            verify(dreamRepository).findAllByMemberIdAndIsDeletedFalse(testMember.getId(), pageable);
+            verify(dreamRepository).findAllByMemberIdAndIsDeletedFalse(testMember.getId(),
+                pageable);
         }
     }
 
     @Nested
     @DisplayName("공개/비공개 꿈일기 목록 조회 테스트")
-    class VisibilityTests {
+    class DreamsListVisibilityTest {
 
         private Pageable pageable;
         private Member testMember;
@@ -298,7 +305,8 @@ class DreamServiceTest {
             publicDream = Dream.builder().member(testMember).title("공개 꿈").isPublic(true).build();
             ReflectionTestUtils.setField(publicDream, "id", 301L);
 
-            privateDream = Dream.builder().member(testMember).title("비공개 꿈").isPublic(false).build();
+            privateDream = Dream.builder().member(testMember).title("비공개 꿈").isPublic(false)
+                .build();
             ReflectionTestUtils.setField(privateDream, "id", 302L);
         }
 
@@ -313,7 +321,8 @@ class DreamServiceTest {
                 .thenReturn(myDreamsPage);
 
             // when
-            Page<DreamSimpleResponse> resultPage = dreamService.getMyDreams(testMember.getId(), pageable);
+            Page<DreamSimpleResponse> resultPage = dreamService.getMyDreams(testMember.getId(),
+                pageable);
 
             // then
             assertThat(resultPage).isNotNull();
@@ -322,7 +331,8 @@ class DreamServiceTest {
                 .extracting(DreamSimpleResponse::title)
                 .containsExactlyInAnyOrder("공개 꿈", "비공개 꿈");
 
-            verify(dreamRepository).findAllByMemberIdAndIsDeletedFalse(testMember.getId(), pageable);
+            verify(dreamRepository).findAllByMemberIdAndIsDeletedFalse(testMember.getId(),
+                pageable);
         }
 
         @Test
@@ -330,7 +340,8 @@ class DreamServiceTest {
         void getPublicDreams_whenCalled_shouldReturnOnlyPublicDreams() {
             // given
             List<Dream> publicDreamsOnly = List.of(publicDream);
-            Page<Dream> publicDreamsPage = new PageImpl<>(publicDreamsOnly, pageable, publicDreamsOnly.size());
+            Page<Dream> publicDreamsPage = new PageImpl<>(publicDreamsOnly, pageable,
+                publicDreamsOnly.size());
 
             when(dreamRepository.findAllByIsPublicTrueAndIsDeletedFalse(pageable))
                 .thenReturn(publicDreamsPage);
@@ -352,20 +363,24 @@ class DreamServiceTest {
         void getPublicDreamsByMember_whenCalled_shouldReturnOnlyPublicDreamsOfMember() {
             // given
             List<Dream> publicDreamsOnly = List.of(publicDream);
-            Page<Dream> publicDreamsPage = new PageImpl<>(publicDreamsOnly, pageable, publicDreamsOnly.size());
+            Page<Dream> publicDreamsPage = new PageImpl<>(publicDreamsOnly, pageable,
+                publicDreamsOnly.size());
 
-            when(dreamRepository.findAllByMemberIdAndIsDeletedFalseAndIsPublicTrue(testMember.getId(), pageable))
+            when(dreamRepository.findAllByMemberIdAndIsDeletedFalseAndIsPublicTrue(
+                testMember.getId(), pageable))
                 .thenReturn(publicDreamsPage);
 
             // when
-            Page<DreamSimpleResponse> resultPage = dreamService.getPublicDreamsByMember(testMember.getId(), pageable);
+            Page<DreamSimpleResponse> resultPage = dreamService.getPublicDreamsByMember(
+                testMember.getId(), pageable);
 
             // then
             assertThat(resultPage).isNotNull();
             assertThat(resultPage.getTotalElements()).isEqualTo(1);
             assertThat(resultPage.getContent().get(0).title()).isEqualTo("공개 꿈");
 
-            verify(dreamRepository).findAllByMemberIdAndIsDeletedFalseAndIsPublicTrue(testMember.getId(), pageable);
+            verify(dreamRepository).findAllByMemberIdAndIsDeletedFalseAndIsPublicTrue(
+                testMember.getId(), pageable);
         }
     }
 
@@ -432,7 +447,8 @@ class DreamServiceTest {
         void getAllDreams_whenExcludingDeleted_shouldReturnOnlyNotDeletedDreams() {
             // given
             List<Dream> notDeletedDreams = List.of(activeDream);
-            Page<Dream> dreamsPage = new PageImpl<>(notDeletedDreams, pageable, notDeletedDreams.size());
+            Page<Dream> dreamsPage = new PageImpl<>(notDeletedDreams, pageable,
+                notDeletedDreams.size());
 
             when(dreamRepository.findAllByIsDeletedFalse(pageable)).thenReturn(dreamsPage);
 
@@ -534,6 +550,21 @@ class DreamServiceTest {
                 () -> dreamService.deleteDream(nonExistentDreamId, testMember.getId()))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(DreamErrorCode.DREAM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("관리자가 관리자 권한으로 댓글 삭제 시 성공")
+        void deleteDreamByAdmin_whenCalledByAdmin_shouldSucceed() {
+            // given
+            when(dreamRepository.findByIdAndIsDeletedFalse(testDream.getId())).thenReturn(
+                Optional.of(testDream));
+
+            // when
+            dreamService.deleteDreamByAdmin(testDream.getId());
+
+            // then
+            assertThat(testDream.isDeleted()).isTrue();
+            verify(dreamRepository).findByIdAndIsDeletedFalse(testDream.getId());
         }
     }
 }


### PR DESCRIPTION
- 관리자용 꿈일기 삭제 로직 구현
- DreamController 관리자용 메서드에 @PreAuthorize로 권한 검사 추가