### PR TITLE
feat(swagger): Springdoc OpenAPI(Swagger)를 이용한 API 문서 자동화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
 }
 
 tasks.named('test') {

--- a/src/main/java/dev/wgrgwg/somniverse/config/SwaggerConfig.java
+++ b/src/main/java/dev/wgrgwg/somniverse/config/SwaggerConfig.java
@@ -1,0 +1,32 @@
+package dev.wgrgwg.somniverse.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+
+        Info info = new Info().title("Somniverse API").version("v0.1.0")
+            .description("Somniverse 프로젝트의 API 명세서입니다.");
+
+        String jwtSchemeName = "JWT-Token";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+        
+        Components components = new Components()
+            .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                .name(jwtSchemeName)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT"));
+
+        return new OpenAPI().info(info).addSecurityItem(securityRequirement).components(components);
+    }
+}

--- a/src/main/java/dev/wgrgwg/somniverse/security/config/SecurityConfig.java
+++ b/src/main/java/dev/wgrgwg/somniverse/security/config/SecurityConfig.java
@@ -23,6 +23,15 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private static final String[] AUTH_WHITELIST = {
+        "/",
+        "/error",
+        "/api/auth/**",
+        "/swagger-ui/**",
+        "/v3/api-docs/**",
+        "/swagger-resources/**"
+    };
+
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2AuthenticationSuccessHandler oauth2AuthenticationSuccessHandler;
@@ -48,7 +57,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/dreams/admin/**", "/api/comments/admin/**")
                 .hasAnyAuthority("ADMIN", "MANAGER")
-                .requestMatchers("/", "/api/auth/**", "/error").permitAll()
+                .requestMatchers(AUTH_WHITELIST).permitAll()
                 .anyRequest().authenticated())
             .oauth2Login(oauth2 -> oauth2
                 .userInfoEndpoint(userInfo -> userInfo


### PR DESCRIPTION
- 프로젝트의 API 명세를 효율적으로 관리하고, 프론트엔드 개발 및 API 테스트의 편의성을 높이기 위해 Springdoc OpenAPI (Swagger UI) 라이브러리를 도입
- `/swagger-ui.html` 경로로 API 엔드포인트를 시각적으로 확인, 직접 테스트 가능