### PR TITLE
fix: Dream, Comment api 수정

### DIFF
--- a/src/main/java/dev/wgrgwg/somniverse/comment/dto/response/CommentResponse.java
+++ b/src/main/java/dev/wgrgwg/somniverse/comment/dto/response/CommentResponse.java
@@ -2,12 +2,13 @@ package dev.wgrgwg.somniverse.comment.dto.response;
 
 import dev.wgrgwg.somniverse.comment.domain.Comment;
 import dev.wgrgwg.somniverse.comment.message.CommentMessage;
+import dev.wgrgwg.somniverse.member.dto.response.MemberResponse;
 import java.time.LocalDateTime;
 
 public record CommentResponse(
     Long id,
     String content,
-    String author,
+    MemberResponse author,
     LocalDateTime createdAt,
     LocalDateTime updatedAt,
     boolean isDeleted,
@@ -37,7 +38,7 @@ public record CommentResponse(
         return new CommentResponse(
             comment.getId(),
             content,
-            comment.getMember().getUsername(),
+            MemberResponse.fromEntity(comment.getMember()),
             comment.getCreatedAt(),
             comment.getUpdatedAt(),
             comment.isDeleted(),

--- a/src/main/java/dev/wgrgwg/somniverse/comment/service/CommentService.java
+++ b/src/main/java/dev/wgrgwg/somniverse/comment/service/CommentService.java
@@ -75,8 +75,6 @@ public class CommentService {
     @Transactional(readOnly = true)
     public Page<CommentResponse> getPagedChildrenCommentsByParent(Long parentId, boolean isAdmin,
         Pageable pageable) {
-        getCommentOrThrow(parentId);
-
         Page<Comment> commentsPage = commentRepository.findAllByParentId(parentId, pageable);
 
         return commentsPage.map(comment -> convertToDtoWithAccessControl(comment, isAdmin, 0L));

--- a/src/main/java/dev/wgrgwg/somniverse/dream/dto/request/DreamCreateRequest.java
+++ b/src/main/java/dev/wgrgwg/somniverse/dream/dto/request/DreamCreateRequest.java
@@ -1,8 +1,8 @@
 package dev.wgrgwg.somniverse.dream.dto.request;
 
-import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 
@@ -15,7 +15,7 @@ public record DreamCreateRequest(
     String content,
 
     @NotNull(message = "꿈을 꾼 날짜는 필수 입력 항목입니다.")
-    @FutureOrPresent(message = "꿈을 꾼 날짜는 현재 또는 미래일 수 없습니다.")
+    @PastOrPresent(message = "꿈을 꾼 날짜는 현재 또는 미래일 수 없습니다.")
     LocalDate dreamDate,
 
     @NotNull(message = "공개 여부는 필수 입력 항목입니다.")

--- a/src/main/java/dev/wgrgwg/somniverse/dream/dto/request/DreamUpdateRequest.java
+++ b/src/main/java/dev/wgrgwg/somniverse/dream/dto/request/DreamUpdateRequest.java
@@ -1,8 +1,8 @@
 package dev.wgrgwg.somniverse.dream.dto.request;
 
-import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 
@@ -15,7 +15,7 @@ public record DreamUpdateRequest(
     String content,
 
     @NotNull(message = "꿈을 꾼 날짜는 필수 입력 항목입니다.")
-    @FutureOrPresent(message = "꿈을 꾼 날짜는 현재 또는 미래일 수 없습니다.")
+    @PastOrPresent(message = "꿈을 꾼 날짜는 현재 또는 미래일 수 없습니다.")
     LocalDate dreamDate,
 
     @NotNull(message = "공개 여부는 필수 입력 항목입니다.")

--- a/src/test/java/dev/wgrgwg/somniverse/comment/controller/CommentControllerTest.java
+++ b/src/test/java/dev/wgrgwg/somniverse/comment/controller/CommentControllerTest.java
@@ -24,6 +24,7 @@ import dev.wgrgwg.somniverse.comment.service.CommentService;
 import dev.wgrgwg.somniverse.dream.service.DreamService;
 import dev.wgrgwg.somniverse.global.exception.CustomException;
 import dev.wgrgwg.somniverse.global.util.RefreshTokenCookieUtil;
+import dev.wgrgwg.somniverse.member.dto.response.MemberResponse;
 import dev.wgrgwg.somniverse.member.repository.AccessTokenBlackListRepository;
 import dev.wgrgwg.somniverse.member.service.AuthService;
 import dev.wgrgwg.somniverse.security.config.SecurityConfig;
@@ -96,7 +97,10 @@ class CommentControllerTest {
         void createComment_success_test() throws Exception {
             // given
             CommentCreateRequest request = new CommentCreateRequest("댓글 내용", null);
-            CommentResponse response = new CommentResponse(1L, "댓글 내용", "작성자", LocalDateTime.now(),
+            MemberResponse memberResponse = new MemberResponse(1L, "user01@email.com", "user01",
+                "작성자", LocalDateTime.now());
+            CommentResponse response = new CommentResponse(1L, "댓글 내용", memberResponse,
+                LocalDateTime.now(),
                 LocalDateTime.now(), false, null, null);
             when(commentService.createComment(anyLong(), any(CommentCreateRequest.class),
                 anyLong())).thenReturn(response);
@@ -126,7 +130,10 @@ class CommentControllerTest {
         void updateComment_success_test() throws Exception {
             // given
             CommentUpdateRequest request = new CommentUpdateRequest("수정된 댓글", null);
-            CommentResponse response = new CommentResponse(1L, "수정된 댓글", "작성자", LocalDateTime.now(),
+            MemberResponse memberResponse = new MemberResponse(1L, "user01@email.com", "user01",
+                "작성자", LocalDateTime.now());
+            CommentResponse response = new CommentResponse(1L, "수정된 댓글", memberResponse,
+                LocalDateTime.now(),
                 LocalDateTime.now(), false, null, null);
             when(commentService.updateComment(anyLong(), any(CommentUpdateRequest.class),
                 anyLong())).thenReturn(response);


### PR DESCRIPTION
다음 기능들을 수정, 구현
- Comment 응답 dto 수정
  - CommentResponse의 작성자 관련 정보를 MemberResponse로 반환하도록 수정
- 대댓글 불러오기 로직 수정
  - 삭제된 댓글에 대한 대댓글들을 정상적으로 불러오도록 수정
- DreamDate의 유효성 검사 어노테이션 수정
  - 현재, 또는 과거의 날짜만 허용하도록 `@PastOrPresent`로 어노테이션 수정