### PR TITLE
feat(member): 내 정보 조회 api 구현

### DIFF
--- a/src/main/java/dev/wgrgwg/somniverse/member/controller/MemberController.java
+++ b/src/main/java/dev/wgrgwg/somniverse/member/controller/MemberController.java
@@ -5,25 +5,28 @@ import dev.wgrgwg.somniverse.member.dto.request.SignupRequest;
 import dev.wgrgwg.somniverse.member.dto.response.MemberResponse;
 import dev.wgrgwg.somniverse.member.message.MemberSuccessMessage;
 import dev.wgrgwg.somniverse.member.service.MemberService;
+import dev.wgrgwg.somniverse.security.userdetails.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/auth")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 @Slf4j
 public class MemberController {
 
     private final MemberService memberService;
 
-    @PostMapping("/members")
+    @PostMapping("/auth/members")
     public ResponseEntity<ApiResponseDto<MemberResponse>> signup(@Valid @RequestBody
     SignupRequest signupRequest) {
         MemberResponse memberResponse = memberService.signup(signupRequest);
@@ -32,5 +35,15 @@ public class MemberController {
             .status(HttpStatus.CREATED)
             .body(ApiResponseDto.success(MemberSuccessMessage.SIGNUP_SUCCESS.getMessage(),
                 memberResponse));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponseDto<MemberResponse>> getMember(@AuthenticationPrincipal
+    CustomUserDetails userDetails) {
+        Long memberId = userDetails.getMember().getId();
+
+        MemberResponse response = memberService.getMember(memberId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.success(response));
     }
 }

--- a/src/main/java/dev/wgrgwg/somniverse/member/service/MemberService.java
+++ b/src/main/java/dev/wgrgwg/somniverse/member/service/MemberService.java
@@ -77,6 +77,11 @@ public class MemberService {
         return MemberAdminResponse.fromEntity(member);
     }
 
+    @Transactional(readOnly = true)
+    public MemberResponse getMember(Long memberId) {
+        return MemberResponse.fromEntity(getMemberOrThrow(memberId));
+    }
+
     public Member getMemberOrThrow(Long id) {
         return memberRepository.findById(id)
             .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,12 @@
+app:
+  jwt:
+    access-token-expiration-ms: 900000
+    refresh-token-expiration-ms: 604800000
+    secret: 'test-secret'
+
+  oauth:
+    authorized-redirect-uri: http://localhost:5173/auth/callback
+
+  cors:
+    allowed-origins:
+      - http://localhost:5173

--- a/src/test/java/dev/wgrgwg/somniverse/comment/controller/AdminCommentControllerTest.java
+++ b/src/test/java/dev/wgrgwg/somniverse/comment/controller/AdminCommentControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.wgrgwg.somniverse.comment.service.CommentService;
+import dev.wgrgwg.somniverse.config.AppProperties;
 import dev.wgrgwg.somniverse.dream.service.DreamService;
 import dev.wgrgwg.somniverse.global.util.RefreshTokenCookieUtil;
 import dev.wgrgwg.somniverse.member.repository.AccessTokenBlackListRepository;
@@ -23,14 +24,19 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @WebMvcTest(AdminCommentController.class)
 @Import(SecurityConfig.class)
+@ActiveProfiles("test")
+@EnableConfigurationProperties(AppProperties.class)
 class AdminCommentControllerTest {
 
     @Autowired
@@ -65,6 +71,9 @@ class AdminCommentControllerTest {
 
     @MockitoBean
     private OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
+
+    @MockitoBean
+    private ClientRegistrationRepository clientRegistrationRepository;
 
     @Nested
     @DisplayName("관리자 댓글 삭제 API 테스트")

--- a/src/test/java/dev/wgrgwg/somniverse/comment/controller/CommentControllerTest.java
+++ b/src/test/java/dev/wgrgwg/somniverse/comment/controller/CommentControllerTest.java
@@ -21,6 +21,7 @@ import dev.wgrgwg.somniverse.comment.dto.request.CommentUpdateRequest;
 import dev.wgrgwg.somniverse.comment.dto.response.CommentResponse;
 import dev.wgrgwg.somniverse.comment.exception.CommentErrorCode;
 import dev.wgrgwg.somniverse.comment.service.CommentService;
+import dev.wgrgwg.somniverse.config.AppProperties;
 import dev.wgrgwg.somniverse.dream.service.DreamService;
 import dev.wgrgwg.somniverse.global.exception.CustomException;
 import dev.wgrgwg.somniverse.global.util.RefreshTokenCookieUtil;
@@ -39,6 +40,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
@@ -46,12 +48,16 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @WebMvcTest(CommentController.class)
 @Import(SecurityConfig.class)
+@ActiveProfiles("test")
+@EnableConfigurationProperties(AppProperties.class)
 class CommentControllerTest {
 
     @Autowired
@@ -86,6 +92,9 @@ class CommentControllerTest {
 
     @MockitoBean
     private OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
+
+    @MockitoBean
+    private ClientRegistrationRepository clientRegistrationRepository;
 
     @Nested
     @DisplayName("댓글 생성 api 테스트")

--- a/src/test/java/dev/wgrgwg/somniverse/comment/service/CommentServiceTest.java
+++ b/src/test/java/dev/wgrgwg/somniverse/comment/service/CommentServiceTest.java
@@ -97,7 +97,7 @@ class CommentServiceTest {
             // then
             assertThat(response).isNotNull();
             assertThat(response.content()).isEqualTo("새 댓글");
-            assertThat(response.author()).isEqualTo(testMember.getUsername());
+            assertThat(response.author().username()).isEqualTo(testMember.getUsername());
             assertThat(response.parentId()).isNull();
             verify(commentRepository).save(any(Comment.class));
         }
@@ -283,8 +283,6 @@ class CommentServiceTest {
         void getPagedChildrenComments_whenWithValidParent_shouldReturnPagedResponse() {
             // given
             Page<Comment> childrenPage = new PageImpl<>(List.of(childComment), pageable, 1);
-            when(commentRepository.findByIdAndIsDeletedFalse(parentComment.getId())).thenReturn(
-                Optional.of(parentComment));
             when(commentRepository.findAllByParentId(parentComment.getId(), pageable)).thenReturn(
                 childrenPage);
 

--- a/src/test/java/dev/wgrgwg/somniverse/dream/controller/AdminDreamControllerTest.java
+++ b/src/test/java/dev/wgrgwg/somniverse/dream/controller/AdminDreamControllerTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.wgrgwg.somniverse.config.AppProperties;
 import dev.wgrgwg.somniverse.dream.dto.response.DreamResponse;
 import dev.wgrgwg.somniverse.dream.dto.response.DreamSimpleResponse;
 import dev.wgrgwg.somniverse.dream.service.DreamService;
@@ -33,18 +34,23 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @WebMvcTest(controllers = AdminDreamController.class)
 @Import(SecurityConfig.class)
+@ActiveProfiles("test")
+@EnableConfigurationProperties(AppProperties.class)
 class AdminDreamControllerTest {
 
     @Autowired
@@ -76,6 +82,9 @@ class AdminDreamControllerTest {
 
     @MockitoBean
     private OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
+
+    @MockitoBean
+    private ClientRegistrationRepository clientRegistrationRepository;
 
     @Nested
     @DisplayName("관리자 권한 꿈일기 조회 api 테스트")

--- a/src/test/java/dev/wgrgwg/somniverse/dream/controller/DreamControllerTest.java
+++ b/src/test/java/dev/wgrgwg/somniverse/dream/controller/DreamControllerTest.java
@@ -15,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.wgrgwg.somniverse.config.AppProperties;
 import dev.wgrgwg.somniverse.dream.dto.request.DreamCreateRequest;
 import dev.wgrgwg.somniverse.dream.dto.request.DreamUpdateRequest;
 import dev.wgrgwg.somniverse.dream.dto.response.DreamResponse;
@@ -40,6 +41,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
@@ -47,12 +49,16 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @WebMvcTest(controllers = DreamController.class)
 @Import(SecurityConfig.class)
+@ActiveProfiles("test")
+@EnableConfigurationProperties(AppProperties.class)
 class DreamControllerTest {
 
     @Autowired
@@ -84,6 +90,9 @@ class DreamControllerTest {
 
     @MockitoBean
     private OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
+
+    @MockitoBean
+    private ClientRegistrationRepository clientRegistrationRepository;
 
     @Nested
     @DisplayName("꿈일기 생성 api 테스트")

--- a/src/test/java/dev/wgrgwg/somniverse/member/controller/AdminMemberControllerTest.java
+++ b/src/test/java/dev/wgrgwg/somniverse/member/controller/AdminMemberControllerTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.wgrgwg.somniverse.comment.service.CommentService;
+import dev.wgrgwg.somniverse.config.AppProperties;
 import dev.wgrgwg.somniverse.dream.service.DreamService;
 import dev.wgrgwg.somniverse.global.util.RefreshTokenCookieUtil;
 import dev.wgrgwg.somniverse.member.domain.Role;
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
@@ -39,12 +41,16 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @WebMvcTest(AdminMemberController.class)
 @Import(SecurityConfig.class)
+@ActiveProfiles("test")
+@EnableConfigurationProperties(AppProperties.class)
 public class AdminMemberControllerTest {
 
     @Autowired
@@ -82,6 +88,9 @@ public class AdminMemberControllerTest {
 
     @MockitoBean
     private OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
+
+    @MockitoBean
+    private ClientRegistrationRepository clientRegistrationRepository;
 
     @Nested
     @DisplayName("관리자 회원 조회 API 테스트")

--- a/src/test/java/dev/wgrgwg/somniverse/member/controller/AuthControllerTest.java
+++ b/src/test/java/dev/wgrgwg/somniverse/member/controller/AuthControllerTest.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.wgrgwg.somniverse.config.AppProperties;
 import dev.wgrgwg.somniverse.global.errorcode.CommonErrorCode;
 import dev.wgrgwg.somniverse.global.exception.CustomException;
 import dev.wgrgwg.somniverse.global.util.RefreshTokenCookieUtil;
@@ -32,18 +33,23 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @WebMvcTest(controllers = AuthController.class)
 @Import(SecurityConfig.class)
+@ActiveProfiles("test")
+@EnableConfigurationProperties(AppProperties.class)
 public class AuthControllerTest {
 
     @Autowired
@@ -72,6 +78,9 @@ public class AuthControllerTest {
 
     @MockitoBean
     private OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
+
+    @MockitoBean
+    private ClientRegistrationRepository clientRegistrationRepository;
 
     @Nested
     @DisplayName("로그인 api 테스트")

--- a/src/test/java/dev/wgrgwg/somniverse/member/service/MemberServiceTest.java
+++ b/src/test/java/dev/wgrgwg/somniverse/member/service/MemberServiceTest.java
@@ -103,6 +103,33 @@ class MemberServiceTest {
     }
 
     @Nested
+    @DisplayName("Member 조회 테스트")
+    class MemberGetTest {
+
+        private Member testMember;
+
+        @BeforeEach
+        void setup() {
+            testMember = Member.builder().id(1L).username("testuser").email("test@email.com")
+                .role(Role.USER).build();
+        }
+
+        @Test
+        @DisplayName("회원 조회 성공 시 MemberResponseDto 반환")
+        void getMember_shouldReturnMemberResponseDto_whenGetMemberSuccess() {
+            // given
+            when(memberRepository.findById(testMember.getId())).thenReturn(Optional.of(testMember));
+
+            // when
+            MemberResponse response = memberService.getMember(testMember.getId());
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.id()).isEqualTo(testMember.getId());
+        }
+    }
+
+    @Nested
     @DisplayName("관리자 기능 테스트")
     class AdminFunctionTests {
 


### PR DESCRIPTION
- 사용자가 내 정보를 조회할 수 있도록 로그인된 사용자의 정보를 MemberResponse로 반환하는 api 구현, 테스트 작성
- WebMvcTest에 SpringSecurity가 의존하는 AppProperties 주입 관련 설정 추가