### PR TITLE
feat: 회원 사용자명 변경 api 구현

### DIFF
--- a/src/main/java/dev/wgrgwg/somniverse/member/controller/MemberController.java
+++ b/src/main/java/dev/wgrgwg/somniverse/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package dev.wgrgwg.somniverse.member.controller;
 
 import dev.wgrgwg.somniverse.global.dto.ApiResponseDto;
+import dev.wgrgwg.somniverse.member.dto.request.MemberUsernameUpdateRequest;
 import dev.wgrgwg.somniverse.member.dto.request.SignupRequest;
 import dev.wgrgwg.somniverse.member.dto.response.MemberResponse;
 import dev.wgrgwg.somniverse.member.message.MemberSuccessMessage;
@@ -13,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,22 +29,32 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/auth/members")
-    public ResponseEntity<ApiResponseDto<MemberResponse>> signup(@Valid @RequestBody
-    SignupRequest signupRequest) {
+    public ResponseEntity<ApiResponseDto<MemberResponse>> signup(
+        @Valid @RequestBody SignupRequest signupRequest) {
         MemberResponse memberResponse = memberService.signup(signupRequest);
 
-        return ResponseEntity
-            .status(HttpStatus.CREATED)
-            .body(ApiResponseDto.success(MemberSuccessMessage.SIGNUP_SUCCESS.getMessage(),
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+            ApiResponseDto.success(MemberSuccessMessage.SIGNUP_SUCCESS.getMessage(),
                 memberResponse));
     }
 
-    @GetMapping("/me")
-    public ResponseEntity<ApiResponseDto<MemberResponse>> getMember(@AuthenticationPrincipal
-    CustomUserDetails userDetails) {
+    @GetMapping("/members/me")
+    public ResponseEntity<ApiResponseDto<MemberResponse>> getMyInfo(
+        @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long memberId = userDetails.getMember().getId();
 
         MemberResponse response = memberService.getMember(memberId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.success(response));
+    }
+
+    @PatchMapping("/members/me")
+    public ResponseEntity<ApiResponseDto<MemberResponse>> updateMemberUsername(
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @Valid @RequestBody MemberUsernameUpdateRequest request) {
+        Long memberId = userDetails.getMember().getId();
+
+        MemberResponse response = memberService.updateMemberUsername(memberId, request);
 
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.success(response));
     }

--- a/src/main/java/dev/wgrgwg/somniverse/member/domain/Member.java
+++ b/src/main/java/dev/wgrgwg/somniverse/member/domain/Member.java
@@ -58,4 +58,8 @@ public class Member {
     public void updateRole(Role role) {
         this.role = role;
     }
+
+    public void updateUsername(String username) {
+        this.username = username;
+    }
 }

--- a/src/main/java/dev/wgrgwg/somniverse/member/dto/request/MemberUsernameUpdateRequest.java
+++ b/src/main/java/dev/wgrgwg/somniverse/member/dto/request/MemberUsernameUpdateRequest.java
@@ -1,0 +1,12 @@
+package dev.wgrgwg.somniverse.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record MemberUsernameUpdateRequest(
+    @NotBlank(message = "사용자명은 필수 입력 항목입니다.")
+    @Size(min = 2, max = 20, message = "사용자명은 2자 이상 20자 이하로 입력해주세요.")
+    String username
+) {
+
+}

--- a/src/main/java/dev/wgrgwg/somniverse/member/service/MemberService.java
+++ b/src/main/java/dev/wgrgwg/somniverse/member/service/MemberService.java
@@ -5,6 +5,7 @@ import dev.wgrgwg.somniverse.member.domain.Member;
 import dev.wgrgwg.somniverse.member.domain.Provider;
 import dev.wgrgwg.somniverse.member.domain.Role;
 import dev.wgrgwg.somniverse.member.dto.request.MemberRoleUpdateRequest;
+import dev.wgrgwg.somniverse.member.dto.request.MemberUsernameUpdateRequest;
 import dev.wgrgwg.somniverse.member.dto.request.SignupRequest;
 import dev.wgrgwg.somniverse.member.dto.response.MemberAdminResponse;
 import dev.wgrgwg.somniverse.member.dto.response.MemberResponse;
@@ -38,11 +39,8 @@ public class MemberService {
 
         String encodedPassword = passwordEncoder.encode(signupRequest.password());
 
-        Member newMember = Member.builder()
-            .username(signupRequest.username())
-            .email(signupRequest.email())
-            .password(encodedPassword)
-            .role(Role.USER)
+        Member newMember = Member.builder().username(signupRequest.username())
+            .email(signupRequest.email()).password(encodedPassword).role(Role.USER)
             .provider(Provider.LOCAL).build();
 
         Member savedMember = memberRepository.save(newMember);
@@ -68,6 +66,19 @@ public class MemberService {
         member.updateRole(request.role());
 
         return MemberAdminResponse.fromEntity(member);
+    }
+
+    @Transactional
+    public MemberResponse updateMemberUsername(Long memberId, MemberUsernameUpdateRequest request) {
+        Member member = getMemberOrThrow(memberId);
+
+        if (memberRepository.existsByUsername(request.username())) {
+            throw new CustomException(MemberErrorCode.USERNAME_ALREADY_EXISTS);
+        }
+
+        member.updateUsername(request.username());
+
+        return MemberResponse.fromEntity(member);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/dev/wgrgwg/somniverse/member/controller/MemberControllerTest.java
+++ b/src/test/java/dev/wgrgwg/somniverse/member/controller/MemberControllerTest.java
@@ -3,6 +3,7 @@ package dev.wgrgwg.somniverse.member.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -13,6 +14,7 @@ import dev.wgrgwg.somniverse.config.AppProperties;
 import dev.wgrgwg.somniverse.global.exception.CustomException;
 import dev.wgrgwg.somniverse.global.util.RefreshTokenCookieUtil;
 import dev.wgrgwg.somniverse.member.domain.Role;
+import dev.wgrgwg.somniverse.member.dto.request.MemberUsernameUpdateRequest;
 import dev.wgrgwg.somniverse.member.dto.request.SignupRequest;
 import dev.wgrgwg.somniverse.member.dto.response.MemberResponse;
 import dev.wgrgwg.somniverse.member.exception.MemberErrorCode;
@@ -176,13 +178,13 @@ class MemberControllerTest {
     class GetMyInfoApiTests {
 
         @Test
-        @DisplayName("내 정보 조회 성공 시 200OK와 MemberResponse 반환")
+        @DisplayName("내 정보 조회 성공 시 200 OK와 MemberResponse 반환")
         void getMyInfo_success_test() throws Exception {
             // given
             when(memberService.getMember(any())).thenReturn(responseDto);
 
             // when
-            ResultActions resultActions = mockMvc.perform(get("/api/me")
+            ResultActions resultActions = mockMvc.perform(get("/api/members/me")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(signupRequestDto)));
 
@@ -193,6 +195,32 @@ class MemberControllerTest {
                 .andExpect(jsonPath("$.data.email").value(responseDto.email()))
                 .andExpect(jsonPath("$.data.username").value(responseDto.username()))
                 .andExpect(jsonPath("$.data.role").value(Role.USER.toString()));
+        }
+
+    }
+
+    @Nested
+    @DisplayName("회원 정보 수정 api 테스트")
+    @WithMockCustomUser
+    class UpdateMemberApiTests {
+
+        @Test
+        @DisplayName("내 사용자명 변경 성공 시 200 OK와 MemberResponse 반환")
+        void updateMemberUsername_success_test() throws Exception {
+            // given
+            when(memberService.updateMemberUsername(any(), any())).thenReturn(responseDto);
+            MemberUsernameUpdateRequest request = new MemberUsernameUpdateRequest("user01");
+
+            // when
+            ResultActions resultActions = mockMvc.perform(patch("/api/members/me")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+            // then
+            resultActions.andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.username").value(responseDto.username()));
         }
 
     }

--- a/src/test/java/dev/wgrgwg/somniverse/member/service/MemberServiceTest.java
+++ b/src/test/java/dev/wgrgwg/somniverse/member/service/MemberServiceTest.java
@@ -14,6 +14,7 @@ import dev.wgrgwg.somniverse.member.domain.Member;
 import dev.wgrgwg.somniverse.member.domain.Provider;
 import dev.wgrgwg.somniverse.member.domain.Role;
 import dev.wgrgwg.somniverse.member.dto.request.MemberRoleUpdateRequest;
+import dev.wgrgwg.somniverse.member.dto.request.MemberUsernameUpdateRequest;
 import dev.wgrgwg.somniverse.member.dto.request.SignupRequest;
 import dev.wgrgwg.somniverse.member.dto.response.MemberAdminResponse;
 import dev.wgrgwg.somniverse.member.dto.response.MemberResponse;
@@ -126,6 +127,36 @@ class MemberServiceTest {
             // then
             assertThat(response).isNotNull();
             assertThat(response.id()).isEqualTo(testMember.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("Member 수정 테스트")
+    class UpdateMemberTest {
+
+        private Member testMember;
+
+        @BeforeEach
+        void setup() {
+            testMember = Member.builder().id(1L).username("testuser").email("test@email.com")
+                .role(Role.USER).build();
+        }
+
+        @Test
+        @DisplayName("회원 사용자명 변경 성공 시 MemberResponseDto 반환")
+        void updateMemberUsername_shouldReturnMemberResponseDto_whenUpdateMemberUsernameSuccess() {
+            // given
+            MemberUsernameUpdateRequest request = new MemberUsernameUpdateRequest("새 사용자명");
+            when(memberRepository.findById(testMember.getId())).thenReturn(Optional.of(testMember));
+            when(memberRepository.existsByUsername(request.username())).thenReturn(false);
+
+            // when
+            MemberResponse response = memberService.updateMemberUsername(testMember.getId(),
+                request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.username()).isEqualTo("새 사용자명");
         }
     }
 


### PR DESCRIPTION
다음 내용들을 구현
- 사용자명 변경 요청을 처리하는 `MemberUsernameUpdateRequest` DTO를 생성
- `MemberService`에 사용자명 중복 검사를 포함한 비즈니스 로직을 구현
- `MemberController`에 사용자명 변경을 위한 `PATCH /api/members/me` 엔드포인트를 추가
- `@AuthenticationPrincipal`을 사용하여 인증된 사용자 본인만 정보를 수정할 수 있도록 구현
- Controller 및 Service 단위 테스트 코드를 작성

