### PR TITLE
feat: 백엔드 서버 자동 배포를 위한 GitHub Actions 워크플로우 구축

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,113 @@
+name: Deploy Backend (prod)
+
+on:
+  workflow_dispatch: { }
+  push:
+    branches: [ main ]
+    paths:
+      - '**/*.java'
+      - 'pom.xml'
+      - 'build.gradle*'
+      - 'settings.gradle*'
+      - 'gradle/**'
+      - 'src/**'
+
+concurrency:
+  group: somniverse-prod-backend
+  cancel-in-progress: false
+
+env:
+  REMOTE_HOST: ${{ secrets.DEPLOY_HOST }}
+  REMOTE_USER: ${{ secrets.DEPLOY_USER }}
+  REMOTE_PORT: ${{ secrets.DEPLOY_SSH_PORT }}
+  REMOTE_DIR: /srv/somniverse
+  HEALTH_LOCAL: http://127.0.0.1:8080/actuator/health
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://somniverse.kro.kr
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Make gradlew executable (if present)
+        run: |
+          if [ -f ./gradlew ]; then chmod +x ./gradlew; fi
+
+      - name: Build with Gradle (if gradle project)
+        if: hashFiles('gradlew') != ''
+        run: |
+          ./gradlew -x test clean bootJar
+          echo "JAR_PATH=$(ls -1 build/libs/*.jar | head -n1)" >> $GITHUB_ENV
+
+      - name: Build with Maven (if maven project)
+        if: hashFiles('pom.xml') != ''
+        run: |
+          ./mvnw -DskipTests -q -B clean package || mvn -DskipTests -q -B clean package
+          echo "JAR_PATH=$(ls -1 target/*.jar | head -n1)" >> $GITHUB_ENV
+
+      - name: Normalize artifact name
+        run: |
+          mkdir -p out
+          cp "$JAR_PATH" out/app.jar
+          ls -lh out/app.jar
+
+      - name: Prepare SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -p "${{ env.REMOTE_PORT || 22 }}" -H "${{ env.REMOTE_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Upload JAR to server
+        run: |
+          scp -P "${{ env.REMOTE_PORT || 22 }}" out/app.jar \
+            "${{ env.REMOTE_USER }}"@"${{ env.REMOTE_HOST }}":"${{ env.REMOTE_DIR }}/backend/app.jar.new"
+
+      - name: Swap JAR, restart, health check (on server)
+        run: |
+          ssh -p "${{ env.REMOTE_PORT || 22 }}" "${{ env.REMOTE_USER }}"@"${{ env.REMOTE_HOST }}" << 'EOF'
+          set -euo pipefail
+          cd /srv/somniverse/backend
+          ts=$(date +%Y%m%d%H%M%S)
+
+          if [ -f app.jar ]; then cp -f app.jar "app.jar.$ts"; fi
+
+          mv -f app.jar.new app.jar
+
+          cd /srv/somniverse
+          docker compose restart backend
+
+          ok=0
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:8080/actuator/health | grep -q '"status":"UP"'; then
+              ok=1; break
+            fi
+            sleep 2
+          done
+
+          if [ "$ok" -ne 1 ]; then
+            echo "Health check failed. Rolling back..."
+            cd /srv/somniverse/backend
+            last="$(ls -1t app.jar.* | head -n1 || true)"
+            if [ -n "$last" ]; then
+              mv -f "$last" app.jar
+              cd /srv/somniverse && docker compose restart backend || true
+            fi
+            exit 1
+          fi
+          EOF
+
+      - name: Smoke test over HTTPS
+        run: |
+          curl -fsS https://somniverse.kro.kr/actuator/health | grep -q '"status":"UP"'

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,8 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
 
     testRuntimeOnly("com.h2database:h2")
+
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 sourceSets {

--- a/src/main/java/dev/wgrgwg/somniverse/security/config/SecurityConfig.java
+++ b/src/main/java/dev/wgrgwg/somniverse/security/config/SecurityConfig.java
@@ -34,7 +34,8 @@ public class SecurityConfig {
         "/api/auth/**",
         "/swagger-ui/**",
         "/v3/api-docs/**",
-        "/swagger-resources/**"
+        "/swagger-resources/**",
+        "/actuator/health"
     };
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;


### PR DESCRIPTION
- **GitHub Actions 워크플로우 추가** (`.github/workflows/deploy-backend.yml`)
  - `main` 브랜치에 소스 코드(`*.java`, `build.gradle` 등)가 푸시될 때 워크플로우가 실행되도록 트리거를 설정
  - Java 21 환경에서 Gradle(또는 Maven)을 사용하여 프로젝트를 빌드하고 JAR 파일을 생성
  - `scp`를 사용하여 빌드된 JAR 파일을 배포 서버로 전송
  - `ssh`를 통해 원격 서버에 접속하여 기존 JAR 파일을 백업하고, 새 JAR 파일로 교체 후 `docker compose restart` 명령으로 애플리케이션을 재시작
  - 배포 실패 시 이전 버전으로 자동 롤백하는 스크립트를 포함
 - Spring Boot Actuator 추가
   - Health Check를 위한 Spring Boot Actuator 의존성 추가, 허용 url 등록