### PR TITLE
refactor: build.gradle 프로필 로직 제거 및 단일 아티팩트 빌드로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,6 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
-def profile = System.getProperty('spring.profiles.active', 'local')
-
 group = 'dev.wgrgwg'
 version = '0.0.1-SNAPSHOT'
 
@@ -51,20 +49,6 @@ dependencies {
     testRuntimeOnly("com.h2database:h2")
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-}
-
-sourceSets {
-    main {
-        resources {
-            srcDirs = ["src/main/resources", "src/main/resources-${profile}"]
-        }
-    }
-}
-
-bootJar {
-    manifest {
-        attributes 'Spring-Boot-Profiles': profile
-    }
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## 작업 내용
`build.gradle` 파일에서 다음과 같은 빌드 시점 프로필 설정 로직을 제거
- `System.getProperty('spring.profiles.active')`를 사용한 프로필 변수 정의
- `sourceSets`에서 프로필에 따라 `src/main/resources-${profile}`을 동적으로 포함하는 부분
- `bootJar` 매니페스트에 `Spring-Boot-Profiles` 속성을 고정하는 부분

## 변경 후 기대 효과
- **CI/CD 파이프라인 단순화:** 이제 `gradle bootJar` 명령만으로 범용 아티팩트를 생성 가능
- **배포 유연성 향상:** 생성된 JAR 파일 하나로, 런타임에 환경 변수만 변경하여 모든 환경(local, dev, prod)에 배포 가능