### PR TITLE
revert: Gradle 빌드 프로필 분리 롤백 및 CI에 프로덕션 프로필 적용

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build with Gradle (if gradle project)
         if: hashFiles('gradlew') != ''
         run: |
-          ./gradlew -x test clean bootJar
+          ./gradlew -x test clean bootJar "-Dspring.profiles.active=prod"
           echo "JAR_PATH=$(ls -1 build/libs/*[!-plain].jar | head -n1)" >> $GITHUB_ENV
 
       - name: Build with Maven (if maven project)

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,8 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
+def profile = System.getProperty('spring.profiles.active', 'local')
+
 group = 'dev.wgrgwg'
 version = '0.0.1-SNAPSHOT'
 
@@ -49,6 +51,20 @@ dependencies {
     testRuntimeOnly("com.h2database:h2")
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+}
+
+sourceSets {
+    main {
+        resources {
+            srcDirs = ["src/main/resources", "src/main/resources-${profile}"]
+        }
+    }
+}
+
+bootJar {
+    manifest {
+        attributes 'Spring-Boot-Profiles': profile
+    }
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## 작업 내용

1.  **Gradle 설정 롤백:** `build.gradle`에서 빌드 시점 프로필 설정 로직을 제거했던 이전 변경사항을 롤백하고, 프로필 기반 리소스(`src/main/resources-${profile}`) 설정을 복원
2.  **CI 워크플로우 수정:** `deploy.yml`의 Gradle 빌드 명령어에 `-Dspring.profiles.active=prod` 옵션을 추가하여, CI 환경에서는 항상 프로덕션 프로필로 빌드되도록 수정

**관련 PR:** Reverts #23