### PR TITLE
fix(healthcheck): 서비스 시작 안정성을 위한 헬스체크 옵션 조정

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -88,15 +88,16 @@ jobs:
           cd /srv/somniverse
           docker compose restart backend
           
-          echo "Waiting 60 seconds for app to initialize..."
-          sleep 60
+          echo "Waiting 300 seconds for app to initialize..."
+          sleep 300
 
           ok=0
-          for i in $(seq 1 30); do
+          for i in $(seq 1 60); do
             if curl -fsS http://127.0.0.1:8080/actuator/health | grep -q '"status":"UP"'; then
+              echo "Health check successful!"
               ok=1; break
             fi
-            sleep 15
+            sleep 10
           done
 
           if [ "$ok" -ne 1 ]; then


### PR DESCRIPTION
## 작업 내용

`deploy-backend.yml` 파일의 ci 백엔드 서비스 헬스체크 옵션을 다음과 같이 조정
- healthcheck 시도 횟수 증가 (30 -> 60)
- healthcheck interval 감소 (15s -> 10s)
- healthcheck start_period 증가 (60s -> 300s)