### PR TITLE
fix: Dream 및 Comment 도메인의 N+1 문제 해결 및 softDelete 성능 개선

### DIFF
--- a/src/main/java/dev/wgrgwg/somniverse/comment/repository/CommentRepository.java
+++ b/src/main/java/dev/wgrgwg/somniverse/comment/repository/CommentRepository.java
@@ -1,11 +1,13 @@
 package dev.wgrgwg.somniverse.comment.repository;
 
 import dev.wgrgwg.somniverse.comment.domain.Comment;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -29,4 +31,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
         "WHERE c.parent.id IN :parentIds AND c.isDeleted = false " +
         "GROUP BY c.parent.id")
     List<Object[]> countChildrenGroupedByParentId(@Param("parentIds") List<Long> parentIds);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Comment c SET c.isDeleted = true, c.deletedAt = :deletedAt WHERE c.dream.id = :dreamId")
+    void softDeleteByDream(@Param("dreamId") Long dreamId,
+        @Param("deletedAt") LocalDateTime deletedAt);
 }

--- a/src/main/java/dev/wgrgwg/somniverse/comment/repository/CommentRepository.java
+++ b/src/main/java/dev/wgrgwg/somniverse/comment/repository/CommentRepository.java
@@ -15,7 +15,14 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     Page<Comment> findAllByParentId(Long parentId, Pageable pageable);
 
-    Page<Comment> findAllByDreamIdAndParentIsNull(Long parentId, Pageable pageable);
+    @Query("""
+        SELECT c
+        FROM Comment c
+        JOIN FETCH c.member
+        WHERE c.dream.id = :dreamId
+        AND c.parent IS NULL
+        """)
+    Page<Comment> findAllByDreamIdAndParentIsNull(Long dreamId, Pageable pageable);
 
     @Query("SELECT c.parent.id, COUNT(c) " +
         "FROM Comment c " +

--- a/src/main/java/dev/wgrgwg/somniverse/dream/domain/Dream.java
+++ b/src/main/java/dev/wgrgwg/somniverse/dream/domain/Dream.java
@@ -75,9 +75,6 @@ public class Dream {
 
     public void softDelete() {
         isDeleted = true;
-        for (Comment comment : comments) {
-            comment.softDelete();
-        }
         deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/dev/wgrgwg/somniverse/dream/repository/DreamRepository.java
+++ b/src/main/java/dev/wgrgwg/somniverse/dream/repository/DreamRepository.java
@@ -5,15 +5,36 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface DreamRepository extends JpaRepository<Dream, Long> {
+
+    @Query("""
+        SELECT d
+        FROM Dream d
+        JOIN FETCH d.member
+        """)
+    Page<Dream> findAllForAdmin(Pageable pageable);
 
     Page<Dream> findAllByMemberIdAndIsDeletedFalse(Long memberId, Pageable pageable);
 
     Page<Dream> findAllByMemberIdAndIsDeletedFalseAndIsPublicTrue(Long memberId, Pageable pageable);
 
+    @Query("""
+        SELECT d
+        FROM Dream d
+        JOIN FETCH d.member
+        WHERE d.isPublic=true
+        AND d.isDeleted=false
+        """)
     Page<Dream> findAllByIsPublicTrueAndIsDeletedFalse(Pageable pageable);
 
+    @Query("""
+        SELECT d
+        FROM Dream d
+        JOIN FETCH d.member
+        WHERE d.isDeleted=false
+        """)
     Page<Dream> findAllByIsDeletedFalse(Pageable pageable);
 
     Optional<Dream> findByIdAndIsDeletedFalse(Long id);

--- a/src/main/java/dev/wgrgwg/somniverse/dream/service/DreamService.java
+++ b/src/main/java/dev/wgrgwg/somniverse/dream/service/DreamService.java
@@ -95,7 +95,7 @@ public class DreamService {
         boolean includeDeleted) {
 
         if (includeDeleted) {
-            return dreamRepository.findAll(pageable).map(DreamSimpleResponse::fromEntity);
+            return dreamRepository.findAllForAdmin(pageable).map(DreamSimpleResponse::fromEntity);
         }
 
         return dreamRepository.findAllByIsDeletedFalse(pageable)

--- a/src/main/java/dev/wgrgwg/somniverse/dream/service/DreamService.java
+++ b/src/main/java/dev/wgrgwg/somniverse/dream/service/DreamService.java
@@ -1,5 +1,6 @@
 package dev.wgrgwg.somniverse.dream.service;
 
+import dev.wgrgwg.somniverse.comment.repository.CommentRepository;
 import dev.wgrgwg.somniverse.dream.domain.Dream;
 import dev.wgrgwg.somniverse.dream.dto.request.DreamCreateRequest;
 import dev.wgrgwg.somniverse.dream.dto.request.DreamUpdateRequest;
@@ -23,6 +24,7 @@ public class DreamService {
 
     private final DreamRepository dreamRepository;
     private final MemberService memberService;
+    private final CommentRepository commentRepository;
 
     @Transactional
     public DreamResponse createDream(DreamCreateRequest request, Long memberId) {
@@ -113,9 +115,12 @@ public class DreamService {
     @Transactional
     public void deleteDream(Long dreamId, Long memberId) {
         Dream dream = getDreamOrThrow(dreamId);
+
         validateOwner(dream, memberId);
 
         dream.softDelete();
+
+        commentRepository.softDeleteByDream(dreamId, dream.getDeletedAt());
     }
 
     @Transactional

--- a/src/test/java/dev/wgrgwg/somniverse/comment/performance/CommentNPlusOneTest.java
+++ b/src/test/java/dev/wgrgwg/somniverse/comment/performance/CommentNPlusOneTest.java
@@ -1,0 +1,94 @@
+package dev.wgrgwg.somniverse.comment.performance;
+
+import dev.wgrgwg.somniverse.comment.repository.CommentRepository;
+import dev.wgrgwg.somniverse.comment.service.CommentService;
+import dev.wgrgwg.somniverse.dream.repository.DreamRepository;
+import dev.wgrgwg.somniverse.dream.service.DreamService;
+import dev.wgrgwg.somniverse.member.domain.Member;
+import dev.wgrgwg.somniverse.member.domain.Role;
+import dev.wgrgwg.somniverse.member.repository.MemberRepository;
+import dev.wgrgwg.somniverse.member.service.MemberService;
+import jakarta.persistence.EntityManager;
+import java.util.stream.IntStream;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@Import(CommentService.class)
+@Transactional
+class CommentNPlusOneTest {
+
+    @Autowired
+    private CommentService commentService;
+
+    @MockitoBean
+    private DreamService dreamService;
+
+    @MockitoBean
+    private MemberService memberService;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private DreamRepository dreamRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private Long dreamId;
+
+    private Statistics stats;
+
+    @BeforeEach
+    void setUp() {
+        stats = em.getEntityManagerFactory().unwrap(SessionFactory.class).getStatistics();
+        stats.setStatisticsEnabled(true);
+        stats.clear();
+
+        var dream = dreamRepository.save(
+            dev.wgrgwg.somniverse.dream.domain.Dream.builder().title("꿈 제목").content("꿈 내용").member(
+                memberRepository.save(
+                    dev.wgrgwg.somniverse.member.domain.Member.builder().email("owner@test.com")
+                        .password("pw").username("owner").role(Role.ADMIN).build())).build());
+        dreamId = dream.getId();
+
+        IntStream.rangeClosed(1, 100).forEach(i -> {
+            Member member = memberRepository.save(
+                dev.wgrgwg.somniverse.member.domain.Member.builder().email("user" + i + "@test.com")
+                    .password("pw").username("user" + i).role(Role.USER).build());
+
+            commentRepository.save(
+                dev.wgrgwg.somniverse.comment.domain.Comment.builder().content("댓글 " + i)
+                    .dream(dream).member(member).build());
+        });
+
+        em.flush();
+        em.clear();
+
+        stats.clear();
+    }
+
+    @Test
+    @DisplayName("댓글 조회 N+1 성능 테스트")
+    void detectNPlusOnePerformance() {
+
+        commentService.getPagedParentCommentsByDream(dreamId, false, PageRequest.of(0, 100));
+
+        System.out.println("총 실행된 쿼리 수 = " + stats.getPrepareStatementCount());
+    }
+}

--- a/src/test/java/dev/wgrgwg/somniverse/dream/performance/DreamNPlusOneTest.java
+++ b/src/test/java/dev/wgrgwg/somniverse/dream/performance/DreamNPlusOneTest.java
@@ -1,0 +1,109 @@
+package dev.wgrgwg.somniverse.dream.performance;
+
+import dev.wgrgwg.somniverse.comment.domain.Comment;
+import dev.wgrgwg.somniverse.comment.repository.CommentRepository;
+import dev.wgrgwg.somniverse.comment.service.CommentService;
+import dev.wgrgwg.somniverse.dream.domain.Dream;
+import dev.wgrgwg.somniverse.dream.repository.DreamRepository;
+import dev.wgrgwg.somniverse.dream.service.DreamService;
+import dev.wgrgwg.somniverse.member.domain.Member;
+import dev.wgrgwg.somniverse.member.domain.Role;
+import dev.wgrgwg.somniverse.member.repository.MemberRepository;
+import dev.wgrgwg.somniverse.member.service.MemberService;
+import jakarta.persistence.EntityManager;
+import java.util.stream.IntStream;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@Import(DreamService.class)
+@Transactional
+class DreamNPlusOneTest {
+
+    @Autowired
+    private DreamService dreamService;
+
+    @MockitoBean
+    private CommentService commentService;
+
+    @MockitoBean
+    private MemberService memberService;
+
+    @Autowired
+    private DreamRepository dreamRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private Statistics stats;
+    private Long dreamId;
+    private Long memberId;
+
+    @BeforeEach
+    void setUp() {
+        stats = em.getEntityManagerFactory().unwrap(SessionFactory.class).getStatistics();
+        stats.setStatisticsEnabled(true);
+        stats.clear();
+
+        Member member = memberRepository.save(
+            Member.builder()
+                .email("user@test.com")
+                .password("pw")
+                .username("user")
+                .role(Role.USER)
+                .build()
+        );
+        memberId = member.getId();
+
+        Dream dream = dreamRepository.save(
+            Dream.builder()
+                .title("테스트 꿈")
+                .content("테스트 내용")
+                .member(member)
+                .build()
+        );
+        dreamId = dream.getId();
+
+        IntStream.rangeClosed(1, 100).forEach(i -> {
+            Comment comment = Comment.builder()
+                .dream(dream)
+                .member(member)
+                .content("댓글 " + i)
+                .build();
+            commentRepository.save(comment);
+        });
+
+        em.flush();
+        em.clear();
+        stats.clear();
+    }
+
+    @Test
+    @DisplayName("Dream 삭제 시 발생하는 쿼리 수 측정")
+    void deleteDreamQueryCount() {
+        // when
+        dreamService.deleteDream(dreamId, memberId);
+
+        em.flush();
+        em.clear();
+
+        // then
+        System.out.println("총 실행된 쿼리 수 = " + stats.getPrepareStatementCount());
+    }
+}

--- a/src/test/java/dev/wgrgwg/somniverse/dream/service/DreamServiceTest.java
+++ b/src/test/java/dev/wgrgwg/somniverse/dream/service/DreamServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import dev.wgrgwg.somniverse.comment.repository.CommentRepository;
 import dev.wgrgwg.somniverse.dream.domain.Dream;
 import dev.wgrgwg.somniverse.dream.dto.request.DreamCreateRequest;
 import dev.wgrgwg.somniverse.dream.dto.request.DreamUpdateRequest;
@@ -40,6 +41,9 @@ class DreamServiceTest {
 
     @Mock
     private DreamRepository dreamRepository;
+
+    @Mock
+    private CommentRepository commentRepository;
 
     @Mock
     private MemberService memberService;
@@ -426,7 +430,7 @@ class DreamServiceTest {
             List<Dream> allDreams = List.of(activeDream, deletedDream);
             Page<Dream> dreamsPage = new PageImpl<>(allDreams, pageable, allDreams.size());
 
-            when(dreamRepository.findAll(pageable)).thenReturn(dreamsPage);
+            when(dreamRepository.findAllForAdmin(pageable)).thenReturn(dreamsPage);
 
             // when
             Page<DreamSimpleResponse> result = dreamService.getAllDreamsForAdmin(pageable, true);
@@ -438,7 +442,7 @@ class DreamServiceTest {
                 .extracting(DreamSimpleResponse::title)
                 .containsExactlyInAnyOrder("삭제되지 않은 꿈", "삭제된 꿈");
 
-            verify(dreamRepository).findAll(pageable);
+            verify(dreamRepository).findAllForAdmin(pageable);
             verify(dreamRepository, never()).findAllByIsDeletedFalse(any());
         }
 

--- a/src/test/java/dev/wgrgwg/somniverse/support/security/TestSecurityConfig.java
+++ b/src/test/java/dev/wgrgwg/somniverse/support/security/TestSecurityConfig.java
@@ -1,0 +1,16 @@
+package dev.wgrgwg.somniverse.support.security;
+
+import java.util.List;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+
+@TestConfiguration
+public class TestSecurityConfig {
+
+    @Bean
+    public ClientRegistrationRepository clientRegistrationRepository() {
+        return new InMemoryClientRegistrationRepository(List.of());
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -13,6 +13,7 @@ spring:
         dialect: org.hibernate.dialect.H2Dialect
         show_sql: true
         format_sql: true
+        generate_statistics: true
     defer-datasource-initialization: true
 
   data:


### PR DESCRIPTION
### 작업 개요
Dream, Comment 도메인에서 발생하던 N+1 문제를 해결하고,
Dream softDelete 과정의 쿼리 성능을 개선했습니다.

---

### 주요 변경 사항
1. **테스트 환경 설정**
   - `TestSecurityConfig` 추가
   - 테스트 실행 시 OAuth2 관련 빈 주입 오류 방지

2. **N+1 문제 재현 테스트 추가**
   - `DreamNPlusOneTest`, `CommentNPlusOneTest` 작성
   - 기존 쿼리 실행 시 N+1 발생 여부 확인 가능

3. **CommentRepository 개선**
   - JPQL `fetch join` 적용
   - 댓글 목록 조회 시 불필요한 쿼리 제거

4. **DreamRepository 개선**
   - JPQL `fetch join` 적용
   - 작성자, 댓글 등 연관 엔티티를 한 번에 조회하도록 수정

5. **Dream softDelete 로직 최적화**
   - Dream 삭제 시 발생하던 N개의 Comment softDelete 쿼리를 벌크 연산으로 대체
   - 전체 쿼리 수 감소 및 성능 향상 확인

---

### 테스트
- `DreamNPlusOneTest`, `CommentNPlusOneTest`를 통해 쿼리 수 비교 검증 완료
- soft delete 시 벌크 연산 적용 후 동작 및 데이터 일관성 확인

---

### 참고
- fetch join 적용 시 페이징 제약사항 (`distinct`, `countQuery`) 처리 주의
- 벌크 연산 이후 영속성 컨텍스트 초기화 필요성 검토 완료
